### PR TITLE
Adding the ASICONE Sep/2025 for submission registration

### DIFF
--- a/asicone_202509/README.md
+++ b/asicone_202509/README.md
@@ -1,0 +1,9 @@
+# ASICONE Sep/2025
+
+This design contains the following designs in a single submission:
+
+- Pseudo-automatic SARADC 5-bit
+- SPI for configuration
+- Two feed-forward ring-oscillators
+
+This README could change in the future.

--- a/asicone_202509/metadata.json
+++ b/asicone_202509/metadata.json
@@ -1,0 +1,14 @@
+{
+  "ProjectName": "asicone_202509",
+  "Shuttle": "MPW 0.13µm Sep 2025(T594)",
+  "Technology": "SG13CMOS",
+  "Design": {
+    "DesignName": "asicone_202509",
+    "FinalGdsName": "asicone_202509.gds",
+    "TopCellName": "asicone_202509",
+    "Width": "1.4140mm",
+    "Height": "1.4140mm",
+    "NumberOfSamples": "10"
+  },
+  "FinalWaferThickness": "200um"
+}


### PR DESCRIPTION
This is a submission registration for a design in SG13CMOS.

For now we only contain the `metadata.json` and `README.md`.
